### PR TITLE
use statement_timeout instead of command_timeout. Patch gino-starlett…

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = aenum,async_lru,asyncpg,cachetools,fastapi,gino_starlette,httpx,mercantile,pendulum,pydantic,pytest,shapely,sqlalchemy,starlette
+known_third_party = aenum,async_lru,asyncpg,cachetools,fastapi,gino,httpx,mercantile,pendulum,pydantic,pytest,shapely,sqlalchemy,starlette

--- a/app/application.py
+++ b/app/application.py
@@ -2,11 +2,11 @@ from contextlib import contextmanager
 from typing import Iterator, Optional
 
 from fastapi import FastAPI
-from gino_starlette import Gino, GinoEngine
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 
+from .gino import Gino, GinoEngine
 from .settings.globals import DATABASE_CONFIG, SQL_REQUEST_TIMEOUT
 
 READ_ENGINE: Optional[GinoEngine] = None
@@ -25,7 +25,7 @@ db = Gino(
     database=DATABASE_CONFIG.database,
     pool_min_size=5,
     pool_max_size=10,
-    kwargs=dict(command_timeout=SQL_REQUEST_TIMEOUT),
+    kwargs=dict(server_settings=dict(statement_timeout=f"{SQL_REQUEST_TIMEOUT}")),
 )
 
 

--- a/app/gino.py
+++ b/app/gino.py
@@ -1,0 +1,223 @@
+"""This is a copy of gino-starlette with some minor modification to suppress QueryCanceledError.
+
+Filed issue here: https://github.com/python-gino/gino-starlette/issues/18
+"""
+
+import asyncio
+import logging
+
+from asyncpg.exceptions import QueryCanceledError
+from gino.api import Gino as _Gino
+from gino.api import GinoExecutor as _Executor
+from gino.engine import GinoConnection as _Connection
+from gino.engine import GinoEngine as _Engine
+from gino.strategies import GinoStrategy
+from sqlalchemy.engine.url import URL, make_url
+from starlette import status
+from starlette.exceptions import HTTPException
+from starlette.types import Receive, Scope, Send
+
+logger = logging.getLogger("gino.ext.starlette")
+
+
+class StarletteModelMixin:
+    @classmethod
+    async def get_or_404(cls, *args, **kwargs):
+        # noinspection PyUnresolvedReferences
+        rv = await cls.get(*args, **kwargs)
+        if rv is None:
+            raise HTTPException(
+                status.HTTP_404_NOT_FOUND, "{} is not found".format(cls.__name__),
+            )
+        return rv
+
+
+# noinspection PyClassHasNoInit
+class GinoExecutor(_Executor):
+    async def first_or_404(self, *args, **kwargs):
+        rv = await self.first(*args, **kwargs)
+        if rv is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "No such data")
+        return rv
+
+
+# noinspection PyClassHasNoInit
+class GinoConnection(_Connection):
+    async def first_or_404(self, *args, **kwargs):
+        rv = await self.first(*args, **kwargs)
+        if rv is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "No such data")
+        return rv
+
+
+# noinspection PyClassHasNoInit
+class GinoEngine(_Engine):
+    connection_cls = GinoConnection
+
+    async def first_or_404(self, *args, **kwargs):
+        rv = await self.first(*args, **kwargs)
+        if rv is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "No such data")
+        return rv
+
+
+class StarletteStrategy(GinoStrategy):
+    name = "starlette"
+    engine_cls = GinoEngine
+
+
+StarletteStrategy()
+
+
+class _Middleware:
+    def __init__(self, app, db):
+        self.app = app
+        self.db = db
+        self._conn_for_req = db.config["use_connection_for_request"]
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and self._conn_for_req:
+            scope["connection"] = await self.db.acquire(lazy=True)
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                conn = scope.pop("connection", None)
+                if conn is not None:
+                    try:
+                        await conn.release()
+                    except QueryCanceledError:
+                        pass
+            return
+
+        await self.app(scope, receive, send)
+
+
+class Gino(_Gino):
+    """Support Starlette server.
+    The common usage looks like this::
+        from starlette.applications import Starlette
+        from gino.ext.starlette import Gino
+        app = Starlette()
+        db = Gino(app, **kwargs)
+    GINO adds a middleware to the Starlette app to setup and cleanup database
+    according to the configurations that passed in the ``kwargs`` parameter.
+    The config includes:
+    * ``driver`` - the database driver, default is ``asyncpg``.
+    * ``host`` - database server host, default is ``localhost``.
+    * ``port`` - database server port, default is ``5432``.
+    * ``user`` - database server user, default is ``postgres``.
+    * ``password`` - database server password, default is empty.
+    * ``database`` - database name, default is ``postgres``.
+    * ``dsn`` - a SQLAlchemy database URL to create the engine, its existence
+      will replace all previous connect arguments.
+    * ``pool_min_size`` - the initial number of connections of the db pool.
+    * ``pool_max_size`` - the maximum number of connections in the db pool.
+    * ``echo`` - enable SQLAlchemy echo mode.
+    * ``ssl`` - SSL context passed to ``asyncpg.connect``, default is ``None``.
+    * ``use_connection_for_request`` - flag to set up lazy connection for
+      requests.
+    * ``retry_limit`` - the number of retries to connect to the database on
+      start up, default is 1.
+    * ``retry_interval`` - seconds to wait between retries, default is 1.
+    * ``kwargs`` - other parameters passed to the specified dialects,
+      like ``asyncpg``. Unrecognized parameters will cause exceptions.
+    If ``use_connection_for_request`` is set to be True, then a lazy connection
+    is available at ``request['connection']``. By default, a database
+    connection is borrowed on the first query, shared in the same execution
+    context, and returned to the pool on response. If you need to release the
+    connection early in the middle to do some long-running tasks, you can
+    simply do this::
+        await request['connection'].release(permanent=False)
+    """
+
+    model_base_classes = _Gino.model_base_classes + (StarletteModelMixin,)
+    query_executor = GinoExecutor
+
+    def __init__(self, app=None, *args, **kwargs):
+        self.config = dict()
+        if "dsn" in kwargs:
+            self.config["dsn"] = make_url(kwargs.pop("dsn"))
+        else:
+            self.config["dsn"] = URL(
+                drivername=kwargs.pop("driver", "asyncpg"),
+                host=kwargs.pop("host", "localhost"),
+                port=kwargs.pop("port", 5432),
+                username=kwargs.pop("user", "postgres"),
+                password=kwargs.pop("password", ""),
+                database=kwargs.pop("database", "postgres"),
+            )
+        self.config["retry_limit"] = kwargs.pop("retry_limit", 1)
+        self.config["retry_interval"] = kwargs.pop("retry_interval", 1)
+        self.config["echo"] = kwargs.pop("echo", False)
+        self.config["min_size"] = kwargs.pop("pool_min_size", 5)
+        self.config["max_size"] = kwargs.pop("pool_max_size", 10)
+        self.config["ssl"] = kwargs.pop("ssl", None)
+        self.config["use_connection_for_request"] = kwargs.pop(
+            "use_connection_for_request", True
+        )
+        self.config["kwargs"] = kwargs.pop("kwargs", dict())
+
+        super().__init__(*args, **kwargs)
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        @app.on_event("startup")
+        async def startup():
+            config = self.config
+            logger.info("Connecting to the database: %r", config["dsn"])
+            retries = 0
+            while True:
+                retries += 1
+                # noinspection PyBroadException
+                try:
+                    await self.set_bind(
+                        config["dsn"],
+                        echo=config["echo"],
+                        min_size=config["min_size"],
+                        max_size=config["max_size"],
+                        ssl=config["ssl"],
+                        **config["kwargs"],
+                    )
+                    break
+                except Exception:
+                    if retries < config["retry_limit"]:
+                        logger.info("Waiting for the database to start...")
+                        await asyncio.sleep(config["retry_interval"])
+                    else:
+                        logger.error(
+                            "Cannot connect to the database; max retries reached."
+                        )
+                        raise
+            msg = "Database connection pool created: "
+            logger.info(
+                msg + repr(self.bind),
+                extra={"color_message": msg + self.bind.repr(color=True)},
+            )
+
+        @app.on_event("shutdown")
+        async def shutdown():
+            msg = "Closing database connection: "
+            logger.info(
+                msg + repr(self.bind),
+                extra={"color_message": msg + self.bind.repr(color=True)},
+            )
+            _bind = self.pop_bind()
+            await _bind.close()
+            msg = "Closed database connection: "
+            logger.info(
+                msg + repr(_bind),
+                extra={"color_message": msg + _bind.repr(color=True)},
+            )
+
+        app.add_middleware(_Middleware, db=self)
+
+    async def first_or_404(self, *args, **kwargs):
+        rv = await self.first(*args, **kwargs)
+        if rv is None:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "No such data")
+        return rv
+
+    async def set_bind(self, bind, loop=None, **kwargs):
+        kwargs.setdefault("strategy", "starlette")
+        return await super().set_bind(bind, loop=loop, **kwargs)

--- a/app/routes/dynamic_vector_tiles.py
+++ b/app/routes/dynamic_vector_tiles.py
@@ -3,11 +3,10 @@ Dynamic vector tiles are generated on the fly.
 The dynamic nature of the service allows users to apply filters using query parameters
 or to change tile resolution using the `@` operator after the `y` index
 """
-
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
-from asyncpg import QueryCanceledError
+from asyncpg.exceptions import QueryCanceledError
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.sql import Select, TableClause
 from sqlalchemy.sql.elements import ColumnClause
@@ -89,4 +88,5 @@ async def dynamic_vector_tile(
             status_code=524,
             detail="A timeout occurred while processing the request. Request canceled.",
         )
-    return tile
+    else:
+        return tile

--- a/app/routes/nasa_viirs_fire_alerts/vector_tiles.py
+++ b/app/routes/nasa_viirs_fire_alerts/vector_tiles.py
@@ -115,7 +115,8 @@ async def nasa_viirs_fire_alerts_tile(
             status_code=524,
             detail="A timeout occurred while processing the request. Request canceled.",
         )
-    return tile
+    else:
+        return tile
 
 
 @router.get(

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -54,4 +54,4 @@ DATABASE_CONFIG: DatabaseURL = DatabaseURL(
 AWS_REGION = config("AWS_REGION", cast=str, default="us-east-1")
 
 TILE_CACHE_URL: Optional[str] = config("TILE_CACHE_URL", cast=str, default=None)
-SQL_REQUEST_TIMEOUT: int = 58
+SQL_REQUEST_TIMEOUT: int = 58000


### PR DESCRIPTION
…e to catch timeout error

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Timeout errors after canceling requests

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- use `statement_timeout` instead of `command_timeout`
- patch gino-starlette to cache QueryCanceledError


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
