### PR TITLE
Fix field metadata for include attributes on dynamic vector tiles

### DIFF
--- a/app/crud/async_db/vector_tiles/nasa_viirs_fire_alerts.py
+++ b/app/crud/async_db/vector_tiles/nasa_viirs_fire_alerts.py
@@ -22,7 +22,7 @@ if latest_version:
     )
     for field in fields:
         if field["is_feature_info"]:
-            COLUMNS.append(db.column(field["field_name"]))
+            COLUMNS.append(db.column(field["name"]))
 
 
 async def get_tile(

--- a/app/crud/sync_db/tile_cache_assets.py
+++ b/app/crud/sync_db/tile_cache_assets.py
@@ -134,7 +134,7 @@ def get_attributes(dataset: str, version: str, asset_type: str) -> List[Dict[str
         #  needs changes to data-api to assure dynamic vector tile caches
         #  also have the implementation parameter in the creation options
         if tile_cache["dataset"] == dataset and tile_cache["version"] == version:
-            return tile_cache["fields"]
+            return tile_cache["metadata"]["fields"]
 
     logger.warning(
         f"Did not find any fields in metadata for {asset_type} of {dataset}.{version}."

--- a/app/crud/sync_db/tile_cache_assets.py
+++ b/app/crud/sync_db/tile_cache_assets.py
@@ -23,7 +23,7 @@ def get_all_tile_caches():
                     versions.version as version,
                     assets.creation_options->'implementation' as implementation,
                     versions.is_latest as is_latest,
-                    assets.fields as fields,
+                    assets.metadata->'fields' as fields,
                     assets.creation_options->'min_zoom' as min_zoom,
                     assets.creation_options->'max_zoom' as max_zoom,
                     version_metadata.content_start_date as min_date,
@@ -134,7 +134,7 @@ def get_attributes(dataset: str, version: str, asset_type: str) -> List[Dict[str
         #  needs changes to data-api to assure dynamic vector tile caches
         #  also have the implementation parameter in the creation options
         if tile_cache["dataset"] == dataset and tile_cache["version"] == version:
-            return tile_cache["metadata"]["fields"]
+            return tile_cache["fields"]
 
     logger.warning(
         f"Did not find any fields in metadata for {asset_type} of {dataset}.{version}."

--- a/app/routes/dynamic_vector_tiles.py
+++ b/app/routes/dynamic_vector_tiles.py
@@ -69,7 +69,7 @@ async def dynamic_vector_tile(
     # if no attributes specified get all feature info fields
     if not include_attribute:
         columns: List[ColumnClause] = [
-            db.column(field["field_name"])
+            db.column(field["name"])
             for field in fields
             if field["is_feature_info"]
         ]
@@ -77,9 +77,9 @@ async def dynamic_vector_tile(
     # otherwise run provided list against feature info list and keep common elements
     else:
         columns = [
-            db.column(field["field_name"])
+            db.column(field["name"])
             for field in fields
-            if field["is_feature_info"] and field["field_name"] in include_attribute
+            if field["is_feature_info"] and field["name"] in include_attribute
         ]
 
     query: Select = get_mvt_table(dataset, version, bbox, extent, columns, filters)

--- a/tests/fixtures/session_start.sql
+++ b/tests/fixtures/session_start.sql
@@ -85,7 +85,6 @@ CREATE TABLE public.assets
     is_default boolean NOT NULL,
     creation_options jsonb,
     metadata jsonb,
-    fields jsonb,
     stats jsonb,
     change_log jsonb[],
     CONSTRAINT assets_pkey PRIMARY KEY (dataset, version, asset_type),
@@ -182,10 +181,10 @@ CREATE INDEX geostore_gfw_geostore_id_idx
 INSERT INTO public.datasets (dataset) VALUES ('nasa_viirs_fire_alerts');
 INSERT INTO public.versions (dataset, version, is_latest, status)
   VALUES ('nasa_viirs_fire_alerts', 'v202003', true, 'saved');
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('nasa_viirs_fire_alerts', 'v202003', 'Geo database table', '{}', '[{"field_name":"test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', '327fdd68-2d07-4ced-99f1-69e7f74b20b7', 'saved', 'my_uri', true, true);
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('nasa_viirs_fire_alerts', 'v202003', 'Dynamic vector tile cache', '{"min_zoom": 0, "max_zoom": 12, "field_attributes": null}', '[{"field_name":"dynamic_test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', '33fd3dee-8f21-4ee6-9a90-e2bd2e1d5533', 'saved', 'my_uri2', true, false);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('nasa_viirs_fire_alerts', 'v202003', 'Geo database table', '{}', '{"fields":[{"name":"test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]}', '327fdd68-2d07-4ced-99f1-69e7f74b20b7', 'saved', 'my_uri', true, true);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('nasa_viirs_fire_alerts', 'v202003', 'Dynamic vector tile cache', '{"min_zoom": 0, "max_zoom": 12, "field_attributes": null}', '{"fields":[{"name":"dynamic_test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]}', '33fd3dee-8f21-4ee6-9a90-e2bd2e1d5533', 'saved', 'my_uri2', true, false);
 INSERT INTO public.version_metadata (dataset, version, content_start_date, content_end_date, id)
     VALUES ('nasa_viirs_fire_alerts', 'v202003', '2019-01-01', '2020-01-01', 'bb5b7bd2-eb83-11ed-a05b-0242ac120003');
 
@@ -195,40 +194,40 @@ INSERT INTO public.versions (dataset, version, is_latest, status)
 INSERT INTO public.version_metadata (dataset, version, content_start_date, content_end_date, id)
     VALUES ('umd_modis_burned_areas', 'v202003', '2019-01-01', '2020-01-01', '10246476-eb84-11ed-a05b-0242ac120003');
 
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('umd_modis_burned_areas', 'v202003', 'Geo database table', '{}', '{}', '[{"field_name":"test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', '327fdd68-2d07-4ced-99f1-69e7f74b20b7', 'saved', 'my_uri8', true, true);
 INSERT INTO public.assets (dataset, version, asset_type, creation_options, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('umd_modis_burned_areas', 'v202003', 'Dynamic vector tile cache', '{"min_zoom": 0, "max_zoom": 12, "field_attributes": null}', '[{"field_name":"dynamic_test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', '33fd3dee-8f21-4ee6-9a90-e2bd2e1d5533', 'saved', 'my_uri9', true, false);
+    VALUES ('umd_modis_burned_areas', 'v202003', 'Geo database table', '{}', '{"fields":[{"name":"test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]}', '327fdd68-2d07-4ced-99f1-69e7f74b20b7', 'saved', 'my_uri8', true, true);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, fields, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('umd_modis_burned_areas', 'v202003', 'Dynamic vector tile cache', '{"min_zoom": 0, "max_zoom": 12, "attributes": null}', '{"fields":[{"name":"dynamic_test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]', '33fd3dee-8f21-4ee6-9a90-e2bd2e1d5533', 'saved', 'my_uri9', true, false);
 
 INSERT INTO public.datasets (dataset) VALUES ('wdpa_protected_areas');
 INSERT INTO public.versions (dataset, version, is_latest, status)
   VALUES ('wdpa_protected_areas', 'v201912', true, 'saved');
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('wdpa_protected_areas', 'v201912', 'Geo database table', '{}', '{}', '[{"field_name":"test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', 'dc647190-c74b-4c9a-865e-e26e90480ec9', 'saved', 'my_uri3', true, true);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('wdpa_protected_areas', 'v201912', 'Geo database table', '{}', '{"fields":[{"name":"test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]}', 'dc647190-c74b-4c9a-865e-e26e90480ec9', 'saved', 'my_uri3', true, true);
 
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('wdpa_protected_areas', 'v201912', 'Static vector tile cache', '{"min_zoom": 0, "max_zoom": 9, "field_attributes": null, "tile_strategy": "discontinuous", "implementation": "default", "layer_style": null}', '{}', '[{"field_name":"static_test", "field_alias": "TEST", "field_type": "text", "field_description": null, "is_feature_info": true, "is_filter": false}]', '0637a11b-18f7-42de-9a15-a0ec488c09b6', 'saved', 'my_uri4', true, false);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('wdpa_protected_areas', 'v201912', 'Static vector tile cache', '{"min_zoom": 0, "max_zoom": 9, "field_attributes": null, "tile_strategy": "discontinuous", "implementation": "default", "layer_style": null}', '{"fields":[{"name":"static_test", "alias": "TEST", "data_type": "text", "description": null, "is_feature_info": true, "is_filter": false}]}', '0637a11b-18f7-42de-9a15-a0ec488c09b6', 'saved', 'my_uri4', true, false);
 
 INSERT INTO public.datasets (dataset) VALUES ('wur_radd_alerts');
 INSERT INTO public.versions (dataset, version, is_latest, status)
   VALUES ('wur_radd_alerts', 'v20201214', true, 'saved');
 
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('wur_radd_alerts', 'v20201214', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 14, "max_static_zoom": 9, "implementation": "default", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '[]', '0637a11b-18f7-42de-9a15-a0ec488c09b7', 'saved', 'my_uri5', true, false);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('wur_radd_alerts', 'v20201214', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 14, "max_static_zoom": 9, "implementation": "default", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '0637a11b-18f7-42de-9a15-a0ec488c09b7', 'saved', 'my_uri5', true, false);
 
 INSERT INTO public.datasets (dataset) VALUES ('umd_tree_cover_loss');
 INSERT INTO public.versions (dataset, version, is_latest, status)
   VALUES ('umd_tree_cover_loss', 'v1.8', true, 'saved');
 
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('umd_tree_cover_loss', 'v1.8', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 12, "max_static_zoom": 12, "implementation": "tcd_30", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '[]', '8086c7f5-5f2f-491f-8792-5fc67b6a7b96', 'saved', 'my_uri6', true, false);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('umd_tree_cover_loss', 'v1.8', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 12, "max_static_zoom": 12, "implementation": "tcd_30", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '8086c7f5-5f2f-491f-8792-5fc67b6a7b96', 'saved', 'my_uri6', true, false);
 
 INSERT INTO public.datasets (dataset) VALUES ('umd_glad_landsat_alerts');
 INSERT INTO public.versions (dataset, version, is_latest, status)
   VALUES ('umd_glad_landsat_alerts', 'v20210101', true, 'saved');
 
-INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, fields, asset_id, status, asset_uri, is_managed, is_default)
-    VALUES ('umd_glad_landsat_alerts', 'v20210101', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 12, "max_static_zoom": 9, "implementation": "default", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '[]', '3ac4028e-798d-4854-9b5e-6a9771ed06ed', 'saved', 'my_uri7', true, false);
+INSERT INTO public.assets (dataset, version, asset_type, creation_options, metadata, asset_id, status, asset_uri, is_managed, is_default)
+    VALUES ('umd_glad_landsat_alerts', 'v20210101', 'Raster tile cache', '{"min_zoom": 0, "max_zoom": 12, "max_static_zoom": 9, "implementation": "default", "symbology": null, "source_asset_id": null, "resampling":"average"}', '{}', '3ac4028e-798d-4854-9b5e-6a9771ed06ed', 'saved', 'my_uri7', true, false);
 
 
 CREATE SCHEMA umd_modis_burned_areas;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
For dynamic vector tiles, we allow users to specify attributes on the table to include in the vector tiles. This code hasn't been updated to using the new metadata structure, causing vector tiles to fail. We haven't noticed until now because this code is cached until a new latest version is set for the dataset, and I just did that to update to a new version of `nasa_viirs_fire_alerts`.

Issue Number: N/A


## What is the new behavior?
Use new metadata structure in the API.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
