### PR TITLE
GTC-2775: Add `_page_size` Query Param to Planet.com Request

### DIFF
--- a/app/routes/planet/raster_tiles.py
+++ b/app/routes/planet/raster_tiles.py
@@ -17,11 +17,11 @@ class PlanetImageMode(str, Enum):
 
 
 class PlanetDateRange(str, Enum):
-    """Available date ranges of Planet Mosaics"""
+    """Available date ranges of Planet Mosaics."""
 
 
 def get_planet_date_ranges() -> List[str]:
-    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}"
+    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}&_page_size=1000"
     resp = httpx.get(url)
     return [mosaic["name"][34:-7] for mosaic in resp.json()["mosaics"]]
 
@@ -50,9 +50,7 @@ async def planet_raster_tile(
     ),
     is_valid_apikey: bool = Depends(is_valid_apikey),
 ) -> Response:
-    """
-    A proxy for Planet Mosaic Tiles
-    """
+    """A proxy for Planet Mosaic Tiles."""
     x, y, z = xyz
 
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Planet.com updated its API to use pagination at some point. To get all the data ranges we set the page size to a large value (`1000`)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The date ranges offered for our [Planet Raster Tile](https://tiles.globalforestwatch.org/#tag/Raster-Tiles/operation/planet_raster_tile_planet_v1_planet_medres_normalized_analytic__z___x___y__png_get) endpoint only go to `2023-12`.

Issue Number: [GTC-2775](https://gfw.atlassian.net/browse/GTC-2775)


## What is the new behavior?
Now that we request a large page size, all date ranges should be available. Namely, the missing `2024` dates.
This change has been made in other repos. [See these comments](https://gfw.atlassian.net/browse/GPV-2834?focusedCommentId=25179) (with links to PRs in Pro and Flagship)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
