### PR TITLE
GTC-2775: Move from `Dev` to `Staging`

### DIFF
--- a/app/routes/planet/raster_tiles.py
+++ b/app/routes/planet/raster_tiles.py
@@ -17,11 +17,11 @@ class PlanetImageMode(str, Enum):
 
 
 class PlanetDateRange(str, Enum):
-    """Available date ranges of Planet Mosaics"""
+    """Available date ranges of Planet Mosaics."""
 
 
 def get_planet_date_ranges() -> List[str]:
-    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}"
+    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}&_page_size=1000"
     resp = httpx.get(url)
     return [mosaic["name"][34:-7] for mosaic in resp.json()["mosaics"]]
 
@@ -50,9 +50,7 @@ async def planet_raster_tile(
     ),
     is_valid_apikey: bool = Depends(is_valid_apikey),
 ) -> Response:
-    """
-    A proxy for Planet Mosaic Tiles
-    """
+    """A proxy for Planet Mosaic Tiles."""
     x, y, z = xyz
 
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Moving gtc-2775 up to staging

[Staging API](https://staging-tiles.globalforestwatch.org/docs#/Raster%20Tiles/planet_raster_tile_planet_v1_planet_medres_normalized_analytic__z___x___y__png_get) shows date rages only to 2023-12:
![Screenshot 2024-05-02 at 1 46 42 PM](https://github.com/wri/gfw-tile-cache/assets/744308/b5523d82-2007-438d-9839-562b36129807)

[Dev API](https://dev-tiles.globalforestwatch.org/docs#/Raster%20Tiles/planet_raster_tile_planet_v1_planet_medres_normalized_analytic__z___x___y__png_get) shows previously missing date ranges up to 2024-03:
![dev_planet_date_ranges](https://github.com/wri/gfw-tile-cache/assets/744308/f4e1f853-ee62-4eda-9f09-accc7dd3c6e7)

