### PR TITLE
GTC-2775: Move `Staging` to `Production`

### DIFF
--- a/app/routes/planet/raster_tiles.py
+++ b/app/routes/planet/raster_tiles.py
@@ -17,11 +17,11 @@ class PlanetImageMode(str, Enum):
 
 
 class PlanetDateRange(str, Enum):
-    """Available date ranges of Planet Mosaics"""
+    """Available date ranges of Planet Mosaics."""
 
 
 def get_planet_date_ranges() -> List[str]:
-    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}"
+    url = f"https://api.planet.com/basemaps/v1/mosaics?api_key={GLOBALS.planet_api_key}&_page_size=1000"
     resp = httpx.get(url)
     return [mosaic["name"][34:-7] for mosaic in resp.json()["mosaics"]]
 
@@ -50,9 +50,7 @@ async def planet_raster_tile(
     ),
     is_valid_apikey: bool = Depends(is_valid_apikey),
 ) -> Response:
-    """
-    A proxy for Planet Mosaic Tiles
-    """
+    """A proxy for Planet Mosaic Tiles."""
     x, y, z = xyz
 
     async with httpx.AsyncClient() as client:


### PR DESCRIPTION
Moving gtc-2775 up to production

[Staging API](https://staging-tiles.globalforestwatch.org/docs#/Raster%20Tiles/planet_raster_tile_planet_v1_planet_medres_normalized_analytic__z___x___y__png_get) shows previously missing date ranges up to 2024-03:
![staging_planet_paging_working](https://github.com/wri/gfw-tile-cache/assets/744308/484ea8ab-285e-4e9f-8fc2-46a5d64513d9)

[Production API](https://tiles.globalforestwatch.org/docs#/Raster%20Tiles/planet_raster_tile_planet_v1_planet_medres_normalized_analytic__z___x___y__png_get) shows date rages only to 2023-12:
![Screenshot 2024-05-03 at 10 50 17 AM](https://github.com/wri/gfw-tile-cache/assets/744308/ad5a62aa-42c4-4b5d-85ae-77314f25b731)


