### PR TITLE
GTC-2781: Enable Dynamic Tree Canopy Density Threshold Attribute to Support VIIRS Fire Alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.10-slim
+FROM --platform=linux/amd64 tiangolo/uvicorn-gunicorn-fastapi:python3.10-slim
 
 # Optional build argument for different environments
 ARG ENV

--- a/app/models/enumerators/nasa_viirs_fire_alerts/supported_attributes.py
+++ b/app/models/enumerators/nasa_viirs_fire_alerts/supported_attributes.py
@@ -32,17 +32,10 @@ class SupportedAttribute(Enum, init="value aggregation_rule"):  # type: ignore
         rule('round(avg("bright_ti5__k"),3)', "bright_ti5__K"),
     )
     FRP_MW = ("frp__MW", rule('sum("frp__MW")', "frp__MW"))
-    UMD_TREE_COVER_DENSITY_2000__THRESHOLD = (
-        "umd_tree_cover_density_2000__threshold",
-        rule(
-            'max("umd_tree_cover_density_2000__threshold")',
-            "umd_tree_cover_density_2000__threshold",
-        ),
-    )
     UMD_TREE_COVER_DENSITY__THRESHOLD = (
         "umd_tree_cover_density__threshold",
         rule(
-            'max("umd_tree_cover_density__threshold")',
+            "mode() WITHIN GROUP (ORDER BY umd_tree_cover_density__threshold)",
             "umd_tree_cover_density__threshold",
         ),
     )


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The `umd_tree_cover_density__threshold` attribute is currently aggregating points using `max()`. It should be using `mode()`

Issue Number: [GTC-2781](https://gfw.atlassian.net/browse/GTC-2781)


## What is the new behavior?
Tree cover density thresholds are calculated using `mode()` 

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

