### PR TITLE
Staging -> production: TCL true color tiles bug 

### DIFF
--- a/lambdas/raster_tiler/lambda_function.py
+++ b/lambdas/raster_tiler/lambda_function.py
@@ -99,20 +99,28 @@ def apply_annual_loss_filter(
         year <= _end_year - 2000
     )
 
-    red: ndarray = np.ones(intensity.shape).astype("uint8") * 228
+    # Construct RGBA bands with floating point values for precision
+    red: np.ndarray = np.ones(intensity.shape).astype("float32") * 228
     green: ndarray = (
-        np.ones(intensity.shape) * 102
+        np.ones(intensity.shape).astype("float32") * 102
         + (72 - zoom)
         - (scaled_intensity * (3 / max(zoom, 1)))
-    ).astype("uint8")
+    )
     blue: ndarray = (
-        np.ones(intensity.shape) * 153 + (33 - zoom) - (intensity / max(zoom, 1))
-    ).astype("uint8")
+        np.ones(intensity.shape).astype("float32") * 153 
+        + (33 - zoom) 
+        - (intensity / max(zoom, 1))
+    )
     alpha: ndarray = (
         (scaled_intensity if zoom < 13 else intensity) * start_year_mask * end_year_mask
-    ).astype("uint8")
+    ).astype("float32")
 
-    return np.array([red, green, blue, alpha])
+    # Ensure GBA values are in [0, 255] range
+    green = np.clip(green, 0, 255).astype("uint8")
+    blue = np.clip(blue, 0, 255).astype("uint8")
+    alpha = np.clip(alpha, 0, 255).astype("uint8")
+
+    return np.array([red.astype("uint8"), green, blue, alpha])
 
 
 ##############################
@@ -352,7 +360,7 @@ def read_tile_cache(dataset, version, implementation, x, y, z, **kwargs) -> ndar
 
     arr = np.array(png)
 
-    return seperate_bands(arr)
+    return separat_bands(arr)
 
 
 ##########################
@@ -360,7 +368,7 @@ def read_tile_cache(dataset, version, implementation, x, y, z, **kwargs) -> ndar
 ##########################
 
 
-def seperate_bands(arr: ndarray) -> ndarray:
+def separat_bands(arr: ndarray) -> ndarray:
 
     logger.debug("Store bands in separate arrays")
     # convert data from (height, width, bands) to (bands, height, width)

--- a/tests/lambda/test_array_functions.py
+++ b/tests/lambda/test_array_functions.py
@@ -3,14 +3,14 @@ import numpy as np
 from lambdas.raster_tiler.lambda_function import (
     array_to_img,
     combine_bands,
-    seperate_bands,
+    separat_bands,
 )
 
 
-def test_seperate_bands():
+def test_separat_bands():
     data = np.array([[[1, 2, 3]], [[1, 2, 3]], [[1, 2, 3]]])
 
-    flip = seperate_bands(data)
+    flip = separat_bands(data)
     assert flip.shape == (3, 1, 3)
     assert np.all(flip[0] == 1)
     assert np.all(flip[1] == 2)
@@ -18,7 +18,7 @@ def test_seperate_bands():
 
     data = np.array([[[1, 2, 3, 4]], [[1, 2, 3, 4]], [[1, 2, 3, 4]]])
 
-    flip = seperate_bands(data)
+    flip = separat_bands(data)
     assert flip.shape == (4, 1, 3)
     assert np.all(flip[0] == 1)
     assert np.all(flip[1] == 2)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [GTC-2916](https://gfw.atlassian.net/browse/GTC-2916)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed bright yellow pixels in TCL true color tile cache
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


[GTC-2916]: https://gfw.atlassian.net/browse/GTC-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ