### PR TITLE
GTC-3143 Titiler endpoint for new drivers of TCL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -46,6 +46,7 @@ from .routes.titiler.gfw_integrated_alerts import router as integrated_alerts_ro
 from .routes.titiler.umd_glad_dist_alerts import router as dist_alerts_router
 from .routes.titiler.gfw_forest_carbon_gross_emissions import router as emissions_router
 from .routes.titiler.gfw_forest_carbon_net_flux import router as carbon_flux_router
+from .routes.titiler.wri_tree_cover_loss_drivers import router as tree_cover_loss_drivers_router
 
 gunicorn_logger = logging.getLogger("gunicorn.error")
 logger.handlers = gunicorn_logger.handlers
@@ -63,6 +64,7 @@ ROUTERS = (
     dist_alerts_router,
     emissions_router,
     carbon_flux_router,
+    tree_cover_loss_drivers_router,
     umd_tree_cover_loss_raster_tiles.router,
     umd_glad_landsat_alerts_raster_tiles.router,
     umd_glad_sentinel2_alerts_raster_tiles.router,

--- a/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
+++ b/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
@@ -76,9 +76,9 @@ class TreeCoverLossDrivers(BaseAlgorithm):
         r, g, b = self._rgb_zeros_array()
 
         for k, colors in self.conf_colors.items():
-            r[self.driver >= k] = colors.red
-            g[self.driver >= k] = colors.green
-            b[self.driver >= k] = colors.blue
+            r[self.driver == k] = colors.red
+            g[self.driver == k] = colors.green
+            b[self.driver == k] = colors.blue
 
         return np.stack([r, g, b], axis=0)
 

--- a/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
+++ b/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
@@ -1,0 +1,103 @@
+from collections import OrderedDict, namedtuple
+from typing import Optional
+
+import numpy as np
+from pydantic import ConfigDict
+from rio_tiler.models import ImageData
+from titiler.core.algorithm import BaseAlgorithm
+
+Colors: namedtuple = namedtuple("Colors", ["red", "green", "blue"])
+
+
+class TreeCoverLossDrivers(BaseAlgorithm):
+    """Visualize drivers of tree cover loss"""
+
+    title: str = "Drivers of tree cover loss"
+    description: str = "Visualize drivers of tree cover loss"
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    conf_colors: OrderedDict[int, tuple] = OrderedDict(
+        {
+            1: Colors(227, 157, 41),   # Permanent agriculture
+            2: Colors(229, 128, 116),  # Hard commodities
+            3: Colors(233, 215, 0),    # Shifting cultivation
+            4: Colors(81, 164, 78),    # Forest management
+            5: Colors(137, 81, 40),    # Wildfires
+            6: Colors(163, 84, 160),   # Settlements and infrastructure
+            7: Colors(58, 32, 154),    # Other natural disturbances
+        }
+    )
+
+    # Value of None for the *_data fields means the tile didn't exist (tile was all
+    # no_data).
+    tree_cover_density_mask: Optional[int] = None
+    tree_cover_density_data: Optional[ImageData] = None
+
+    # metadata
+    input_nbands: int = 2
+    output_nbands: int = 4
+    output_dtype: str = "uint8"
+
+    def __call__(self, img: ImageData) -> ImageData:
+
+        self.driver = img.data[0]
+        self.intensity = img.data[1]
+        self.no_data = img.array.mask[0]
+
+        # self.mask should be True for pixels where we have valid data which is not
+        # filtered out.
+        self.mask = self.create_mask()
+
+        rgb = self.create_true_color_rgb()
+        alpha = self.create_true_color_alpha()
+
+        data = np.vstack([rgb, alpha[np.newaxis, ...]]).astype(self.output_dtype)
+        data = np.ma.MaskedArray(data, mask=False)
+
+        return ImageData(data, assets=img.assets, crs=img.crs, bounds=img.bounds)
+
+    def create_mask(self):
+        mask = ~self.no_data
+
+        if self.tree_cover_density_mask:
+            if self.tree_cover_density_data:
+                mask *= (
+                    self.tree_cover_density_data.array[0, :, :]
+                    >= self.tree_cover_density_mask
+                )
+            else:
+                # There was a full no-data tile for tcd, so we should mask
+                # out everything on the base raster.
+                mask = np.zeros_like(mask)
+
+        return mask
+
+    def create_true_color_rgb(self):
+        r, g, b = self._rgb_zeros_array()
+
+        for k, colors in self.conf_colors.items():
+            r[self.driver >= k] = colors.red
+            g[self.driver >= k] = colors.green
+            b[self.driver >= k] = colors.blue
+
+        return np.stack([r, g, b], axis=0)
+
+    def create_true_color_alpha(self):
+        """Set the transparency (alpha) channel based on intensity input. The
+        intensity multiplier is used to control how isolated pixels fade out at low
+        zoom levels, matching the rendering behavior in Flagship.
+
+        Returns:
+            np.ndarray: Array representing the alpha (transparency) channel, where pixel
+            visibility is adjusted by intensity.
+
+        """
+        alpha = np.where(self.mask, self.intensity, 0)
+        return np.minimum(255, alpha)
+
+    def _rgb_zeros_array(self):
+        r = np.zeros_like(self.driver, dtype=np.uint8)
+        g = np.zeros_like(self.driver, dtype=np.uint8)
+        b = np.zeros_like(self.driver, dtype=np.uint8)
+
+        return r, g, b

--- a/app/routes/titiler/gfw_forest_carbon_gross_emissions.py
+++ b/app/routes/titiler/gfw_forest_carbon_gross_emissions.py
@@ -44,7 +44,7 @@ async def global_forest_carbon_gross_emissions_raster_tile(
     ),
     tree_cover_density_threshold: Optional[TreeCoverDensityThreshold] = Query(
         TreeCoverDensityThreshold.tcd_30,
-        description="Show alerts in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
+        description="Show gross emissions in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
     ),
 ) -> Response:
     """Forest Carbon Gross Emissions raster tiles."""

--- a/app/routes/titiler/wri_tree_cover_loss_drivers.py
+++ b/app/routes/titiler/wri_tree_cover_loss_drivers.py
@@ -11,23 +11,23 @@ from ...crud.sync_db.tile_cache_assets import get_versions
 from ...models.enumerators.tile_caches import TileCacheType
 from .. import raster_xyz
 from ...settings.globals import GLOBALS
-from .algorithms.carbon_net_flux import CarbonNetFlux
+from .algorithms.tree_cover_loss_drivers import TreeCoverLossDrivers
 from .readers import AlertsReader
 
 DATA_LAKE_BUCKET = os.environ.get("DATA_LAKE_BUCKET")
 
 router = APIRouter()
 
-dataset = "gfw_forest_carbon_net_flux"
+dataset = "wri_google_tree_cover_loss_drivers"
 
 
-class GfwForestCarbonNetFlux(str, Enum):
-    latest = "v20240402"
+class WriTreeCoverLossDrivers(str, Enum):
+    latest = "v20241224"
 
 
 _versions = get_versions(dataset, TileCacheType.cog)
 for _version in _versions:
-    extend_enum(GfwForestCarbonNetFlux, _version, _version)
+    extend_enum(WriTreeCoverLossDrivers, _version, _version)
 
 
 @router.get(
@@ -36,17 +36,17 @@ for _version in _versions:
     tags=["Raster Tiles"],
     response_description="PNG Raster Tile",
 )
-async def global_forest_carbon_net_flux_raster_tile(
+async def tree_cover_loss_drivers_raster_tile(
     *,
-    version: GfwForestCarbonNetFlux,
+    version: WriTreeCoverLossDrivers,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
     tree_cover_density_threshold: int = Query(
-        ge=30,
+        ge=10,
         le=100,
-        description="Show net flux in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
+        description="Show drivers in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
     )
 ) -> Response:
-    """Forest Carbon Net Flux raster tiles."""
+    """Tree cover loss drivers raster tiles."""
 
     tile_x, tile_y, zoom = xyz
     bands = ["default", "intensity"]
@@ -56,45 +56,23 @@ async def global_forest_carbon_net_flux_raster_tile(
         # the input `bands` list
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
 
-    carbon_net_flux = CarbonNetFlux(
+    tree_cover_loss_drivers = TreeCoverLossDrivers(
         tree_cover_density_mask=tree_cover_density_threshold,
-        tree_cover_gain_from_height_mask=0,
-        mangrove_stock_2000_mask=0.0,
     )
 
-    filter_datasets = GLOBALS.carbon_flux_filters
+    filter_datasets = GLOBALS.tree_cover_loss_drivers_filters
 
     filter_dataset = filter_datasets["tree_cover_density"]
     with COGReader(
             f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
     ) as reader:
         if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.tree_cover_density_data = reader.tile(tile_x, tile_y, zoom)
+            tree_cover_loss_drivers.tree_cover_density_data = reader.tile(tile_x, tile_y, zoom)
         else:
             print("Non-existent tile, tree_cover_density")
-            carbon_net_flux.tree_cover_density_data = None
+            tree_cover_loss_drivers.tree_cover_density_data = None
 
-    filter_dataset = filter_datasets["tree_cover_gain_from_height"]
-    with COGReader(
-        f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
-    ) as reader:
-        if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.tree_cover_gain_from_height_data = reader.tile(tile_x, tile_y, zoom)
-        else:
-            print("Non-existent tile, tree_cover_gain_from_height")
-            carbon_net_flux.tree_cover_gain_from_height_data = None
-
-    filter_dataset = filter_datasets["mangrove_stock_2000"]
-    with COGReader(
-        f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
-    ) as reader:
-        if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.mangrove_stock_2000_data = reader.tile(tile_x, tile_y, zoom)
-        else:
-            print("Non-existent tile, mangrove")
-            carbon_net_flux.mangrove_stock_2000_data = None
-
-    processed_image = carbon_net_flux(image_data)
+    processed_image = tree_cover_loss_drivers(image_data)
 
     content, media_type = render_image(
         processed_image,

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -26,6 +26,10 @@ carbon_flux_filters = {
     "pre_2000_plantations": {"dataset": "gfw_pre_2000_plantations", "version": "v20200724"}
 }
 
+tree_cover_loss_drivers_filters = {
+    "tree_cover_density": {"dataset": "umd_tree_cover_density_2000", "version": "v1.8"},
+}
+
 
 class Globals(BaseSettings):
     env: str = Field("dev", description="Environment name.")
@@ -92,6 +96,10 @@ class Globals(BaseSettings):
     carbon_flux_filters: Dict = Field(
         carbon_flux_filters,
         description="Datasets that are used as filters for carbon gross emissions"
+    )
+    tree_cover_loss_drivers_filters: Dict = Field(
+        tree_cover_loss_drivers_filters,
+        description="Datasets that are used as filters for tree cover loss drivers"
     )
 
     @field_validator("token", mode="before")


### PR DESCRIPTION
GTC-3143 Titiler endpoint for new drivers of TCL

The new drivers dataset (wri_google_tree_cover_loss_drivers) has 7 categories of drivers. We are filtering by
umd_tree_cover_density_2000/v1.8.

Slight changes to update the arg descriptions in gross_emissions and net_flux.

Tested locally.

