### PR TITLE
Support non default vector tiles

### DIFF
--- a/app/routes/vector_tiles.py
+++ b/app/routes/vector_tiles.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/{dataset}/{version}/default/{z}/{x}/{y}.pbf",
+    "/{dataset}/{version}/{implementation}/{z}/{x}/{y}.pbf",
     response_class=VectorTileResponse,
     tags=["Vector Tiles"],
     response_description="PBF Vector Tile",

--- a/terraform/modules/content_delivery_network/main.tf
+++ b/terraform/modules/content_delivery_network/main.tf
@@ -564,6 +564,31 @@ resource "aws_cloudfront_distribution" "tiles" {
     }
   }
 
+  # Non default static vector tiles are stored on S3
+  # They won't change and can stay in cache for a year
+  # We will set response headers for selected tile caches in S3 if required
+  ordered_cache_behavior {
+    allowed_methods  = local.methods
+    cached_methods   = local.methods
+    target_origin_id = "static"
+    compress         = true
+    path_pattern     = "*.pbf"
+
+    forwarded_values {
+      query_string = false
+      headers      = local.headers
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 31536000 # 1y
+    max_ttl                = 31536000 # 1y
+
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"
@@ -580,7 +605,8 @@ resource "aws_cloudfront_distribution" "tiles" {
 
   tags = var.tags
 
-}
+} 
+
 
 #########################
 ## IAM


### PR DESCRIPTION
We actually can successfully create static vector tile caches with other non-default implementations. However, we never added a CloudFront cache behavior to forward these requests to S3.

I'm following the same pattern as static raster tiles here, where's both a behavior for `default` tile caches and a catch all behavior any path ending in `.png`. Not sure if we really need both or if default does something special, but this seemed like the lower risk change. Honestly, not sure if it's this easy, I can't really test the behavior until I get to dev.