### PR TITLE
GTC-3275 Allow serving new versions for gfw_integrated_alerts

### DIFF
--- a/app/routes/titiler/gfw_integrated_alerts.py
+++ b/app/routes/titiler/gfw_integrated_alerts.py
@@ -1,13 +1,10 @@
 import os
 from typing import Optional, Tuple
 
-from aenum import Enum, extend_enum
 from fastapi import APIRouter, Depends, Query, Response
 from titiler.core.resources.enums import ImageType
 from titiler.core.utils import render_image
 
-from ...crud.sync_db.tile_cache_assets import get_versions
-from ...models.enumerators.tile_caches import TileCacheType
 from ...models.enumerators.titiler import IntegratedAlertConfidence, RenderType
 from .. import DATE_REGEX, raster_xyz
 from .algorithms.integrated_alerts import IntegratedAlerts
@@ -18,21 +15,8 @@ DATA_LAKE_BUCKET = os.environ.get("DATA_LAKE_BUCKET")
 router = APIRouter()
 
 dataset = "gfw_integrated_alerts"
-
-
-class GfwIntegratdAlertsVersions(str, Enum):
-    """GFW Integrated Alerts versions.
-
-    When using `latest` call will be redirected (307) to version tagged
-    as latest.
-    """
-
-    latest = "latest"
-
-
-_versions = get_versions(dataset, TileCacheType.cog)
-for _version in _versions:
-    extend_enum(GfwIntegratdAlertsVersions, _version, _version)
+# We don't set a fixed set of versions that can be used, since we want to be able
+# to serve any new integrated_alerts versiond created since this server started.
 
 
 @router.get(
@@ -43,7 +27,7 @@ for _version in _versions:
 )
 async def gfw_integrated_alerts_raster_tile(
     *,
-    version: GfwIntegratdAlertsVersions,
+    version: str,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
     start_date: Optional[str] = Query(
         None,

--- a/app/routes/titiler/gfw_integrated_alerts.py
+++ b/app/routes/titiler/gfw_integrated_alerts.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional, Tuple
 
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, Query, Response, Path
 from titiler.core.resources.enums import ImageType
 from titiler.core.utils import render_image
 
@@ -27,7 +27,7 @@ dataset = "gfw_integrated_alerts"
 )
 async def gfw_integrated_alerts_raster_tile(
     *,
-    version: str,
+    version: str = Path(..., description="Version name of dataset. Either 'latest' or version string beginning with 'v'"),
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
     start_date: Optional[str] = Query(
         None,


### PR DESCRIPTION
GTC-3275 Allow serving new versions for gfw_integrated_alerts

Don't do validation of the version field of titiler gfw_integrated_alerts/{version}, since we want to be able to serve new versions of gfw_integrated_alerts that have been created since the tile cache server was started.

Tested locally that gfw_integated_alerts/{version} is still served correctly.
