### PR TITLE
GTC-3232 Update carbon flux/removals titiler endpoints

### DIFF
--- a/app/routes/titiler/algorithms/carbon_gross_removals.py
+++ b/app/routes/titiler/algorithms/carbon_gross_removals.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict, namedtuple
-from typing import Optional
 
 import numpy as np
 from pydantic import ConfigDict
@@ -53,17 +52,6 @@ class CarbonGrossRemovals(BaseAlgorithm):
         }
     )
 
-    # Value of None for the *_data fields means the tile didn't exist (tile was all
-    # no_data).
-    tree_cover_density_mask: Optional[int] = None
-    tree_cover_density_data: Optional[ImageData] = None
-
-    tree_cover_gain_from_height_mask: Optional[int] = None
-    tree_cover_gain_from_height_data: Optional[ImageData] = None
-
-    mangrove_stock_2000_mask: Optional[float] = None
-    mangrove_stock_2000_data: Optional[ImageData] = None
-
     # metadata
     input_nbands: int = 2
     output_nbands: int = 4
@@ -75,10 +63,6 @@ class CarbonGrossRemovals(BaseAlgorithm):
         self.intensity = img.data[1]
         self.no_data = img.array.mask[0]
 
-        # self.mask should be True for pixels where we have valid data which is not
-        # filtered out.
-        self.mask = self.create_mask()
-
         rgb = self.create_true_color_rgb()
         alpha = self.create_true_color_alpha()
 
@@ -86,30 +70,6 @@ class CarbonGrossRemovals(BaseAlgorithm):
         data = np.ma.MaskedArray(data, mask=False)
 
         return ImageData(data, assets=img.assets, crs=img.crs, bounds=img.bounds)
-
-    def create_mask(self):
-        mask = ~self.no_data
-
-        # Include a pixel if it has minimum canopy density OR tree cover gain OR
-        # mangroves. Since this is ORing and each condition can only possibly be true
-        # with real data (not the no-data value), we just skip a condition if its
-        # tile was non-existent (all no-data).
-        #
-        #  The masking out of areas with pre-2000 tree plantations must already be
-        #  done in the input dataset.
-        or_conditions = np.zeros_like(mask)
-        if self.tree_cover_density_data:
-            or_conditions = np.where(self.tree_cover_density_data.array[0, :, :]
-                                     >= self.tree_cover_density_mask, True, or_conditions)
-        if self.tree_cover_gain_from_height_data:
-            or_conditions = np.where(self.tree_cover_gain_from_height_data.array[0, :, :]
-                                     > self.tree_cover_gain_from_height_mask, True, or_conditions)
-        if self.mangrove_stock_2000_data:
-            or_conditions = np.where(self.mangrove_stock_2000_data.array[0, :, :]
-                                     > self.mangrove_stock_2000_mask, True, or_conditions)
-        mask *= or_conditions
-
-        return mask
 
     def create_true_color_rgb(self):
         r, g, b = self._rgb_zeros_array()
@@ -129,9 +89,8 @@ class CarbonGrossRemovals(BaseAlgorithm):
         Returns:
             np.ndarray: Array representing the alpha (transparency) channel, where pixel
             visibility is adjusted by intensity.
-
         """
-        alpha = np.where(self.mask, self.intensity, 0)
+        alpha = np.where(~self.no_data, self.intensity, 0)
         return np.minimum(255, alpha)
 
     def _rgb_zeros_array(self):

--- a/app/routes/titiler/algorithms/carbon_net_flux.py
+++ b/app/routes/titiler/algorithms/carbon_net_flux.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict, namedtuple
-from typing import Optional
 
 import numpy as np
 from pydantic import ConfigDict
@@ -86,17 +85,6 @@ class CarbonNetFlux(BaseAlgorithm):
         }
     )
 
-    # Value of None for the *_data fields means the tile didn't exist (tile was all
-    # no_data).
-    tree_cover_density_mask: Optional[int] = None
-    tree_cover_density_data: Optional[ImageData] = None
-
-    tree_cover_gain_from_height_mask: Optional[int] = None
-    tree_cover_gain_from_height_data: Optional[ImageData] = None
-
-    mangrove_stock_2000_mask: Optional[float] = None
-    mangrove_stock_2000_data: Optional[ImageData] = None
-
     # metadata
     input_nbands: int = 2
     output_nbands: int = 4
@@ -108,10 +96,6 @@ class CarbonNetFlux(BaseAlgorithm):
         self.intensity = img.data[1]
         self.no_data = img.array.mask[0]
 
-        # self.mask should be True for pixels where we have valid data which is not
-        # filtered out.
-        self.mask = self.create_mask()
-
         rgb = self.create_true_color_rgb()
         alpha = self.create_true_color_alpha()
 
@@ -119,30 +103,6 @@ class CarbonNetFlux(BaseAlgorithm):
         data = np.ma.MaskedArray(data, mask=False)
 
         return ImageData(data, assets=img.assets, crs=img.crs, bounds=img.bounds)
-
-    def create_mask(self):
-        mask = ~self.no_data
-
-        # Include a pixel if it has minimum canopy density OR tree cover gain OR
-        # mangroves. Since this is ORing and each condition can only possibly be true
-        # with real data (not the no-data value), we just skip a condition if its
-        # tile was non-existent (all no-data).
-        #
-        #  The masking out of areas with pre-2000 tree plantations must already be
-        #  done in the input dataset.
-        or_conditions = np.zeros_like(mask)
-        if self.tree_cover_density_data:
-            or_conditions = np.where(self.tree_cover_density_data.array[0, :, :]
-                                     >= self.tree_cover_density_mask, True, or_conditions)
-        if self.tree_cover_gain_from_height_data:
-            or_conditions = np.where(self.tree_cover_gain_from_height_data.array[0, :, :]
-                                     > self.tree_cover_gain_from_height_mask, True, or_conditions)
-        if self.mangrove_stock_2000_data:
-            or_conditions = np.where(self.mangrove_stock_2000_data.array[0, :, :]
-                                     > self.mangrove_stock_2000_mask, True, or_conditions)
-        mask *= or_conditions
-
-        return mask
 
     def create_true_color_rgb(self):
         r, g, b = self._rgb_zeros_array()
@@ -162,9 +122,8 @@ class CarbonNetFlux(BaseAlgorithm):
         Returns:
             np.ndarray: Array representing the alpha (transparency) channel, where pixel
             visibility is adjusted by intensity.
-
         """
-        alpha = np.where(self.mask, self.intensity, 0)
+        alpha = np.where(~self.no_data, self.intensity, 0)
         return np.minimum(255, alpha)
 
     def _rgb_zeros_array(self):

--- a/app/routes/titiler/gfw_forest_carbon_gross_emissions.py
+++ b/app/routes/titiler/gfw_forest_carbon_gross_emissions.py
@@ -21,7 +21,7 @@ dataset = "gfw_forest_carbon_gross_emissions"
 
 
 class GfwForestCarbonGrossEmissions(str, Enum):
-    latest = "v20240402"
+    latest = "v20250430"
 
 
 _versions = get_versions(dataset, TileCacheType.cog)
@@ -55,9 +55,7 @@ async def global_forest_carbon_gross_emissions_raster_tile(
         f"intensity_tcd_{tree_cover_density_threshold}",
     ]
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
-    with AlertsReader(
-        input=folder, default_band=f"emission_tcd_{tree_cover_density_threshold}"
-    ) as reader:
+    with AlertsReader(input=folder, default_band=bands[0]) as reader:
         # NOTE: the bands in the output `image_data` array will be in the order of
         # the input `bands` list
         image_data = reader.tile(

--- a/app/routes/titiler/gfw_forest_carbon_gross_removals.py
+++ b/app/routes/titiler/gfw_forest_carbon_gross_removals.py
@@ -1,17 +1,15 @@
 import os
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional
 
 from aenum import Enum, extend_enum
 from fastapi import APIRouter, Depends, Query, Response
-from rio_tiler.io import COGReader
-from rio_tiler.models import ImageData
 from titiler.core.resources.enums import ImageType
 from titiler.core.utils import render_image
 
 from ...crud.sync_db.tile_cache_assets import get_versions
 from ...models.enumerators.tile_caches import TileCacheType
+from ...models.enumerators.titiler import TreeCoverDensityThreshold
 from .. import raster_xyz
-from ...settings.globals import GLOBALS
 from .algorithms.carbon_gross_removals import CarbonGrossRemovals
 from .readers import AlertsReader
 
@@ -23,7 +21,7 @@ dataset = "gfw_forest_carbon_gross_removals"
 
 
 class GfwForestCarbonGrossRemovals(str, Enum):
-    latest = "v20240308"
+    latest = "v20250416"
 
 
 _versions = get_versions(dataset, TileCacheType.cog)
@@ -41,49 +39,27 @@ async def global_forest_carbon_gross_removals_raster_tile(
     *,
     version: GfwForestCarbonGrossRemovals,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
-    tree_cover_density_threshold: int = Query(
-        ge=30,
-        le=100,
-        description="Show data in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
+    tree_cover_density_threshold: Optional[TreeCoverDensityThreshold] = Query(
+        TreeCoverDensityThreshold.tcd_30,
+        description="Show gross removals in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
     )
 ) -> Response:
     """Forest Carbon Gross Removals raster tiles."""
 
     tile_x, tile_y, zoom = xyz
-    bands: List[str] = ["removals", "intensity"]
+    bands = [
+        f"emission_tcd_{tree_cover_density_threshold}",
+        f"intensity_tcd_{tree_cover_density_threshold}",
+    ]
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
-
     with AlertsReader(input=folder, default_band=bands[0]) as reader:
         # NOTE: the bands in the output `image_data` array will be in the order of
         # the input `bands` list
-        image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
+        image_data = reader.tile(
+            tile_x, tile_y, zoom, bands=bands
+        )
 
-    carbon_gross_removals = CarbonGrossRemovals(
-        tree_cover_density_mask=tree_cover_density_threshold,
-        tree_cover_gain_from_height_mask=0,
-        mangrove_stock_2000_mask=0.0,
-    )
-
-    filter_datasets = GLOBALS.carbon_flux_filters
-
-    for filter_name, details in filter_datasets.items():
-        with COGReader(
-            f"s3://{DATA_LAKE_BUCKET}/{details['dataset']}/{details['version']}/raster/epsg-4326/cog/default.tif"
-        ) as reader:
-            filter_data: Optional[ImageData] = None
-
-            if reader.tile_exists(tile_x, tile_y, zoom):
-                filter_data = reader.tile(tile_x, tile_y, zoom)
-            else:
-                print(f"Non-existent tile for filter {filter_name} at z={zoom}, x={tile_x}, y={tile_y}")
-
-            setattr(
-                carbon_gross_removals,
-                f"{filter_name}_data",
-                filter_data
-            )
-
-    processed_image = carbon_gross_removals(image_data)
+    processed_image = CarbonGrossRemovals()(image_data)
 
     content, media_type = render_image(
         processed_image,

--- a/app/routes/titiler/gfw_forest_carbon_net_flux.py
+++ b/app/routes/titiler/gfw_forest_carbon_net_flux.py
@@ -1,16 +1,15 @@
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 from aenum import Enum, extend_enum
 from fastapi import APIRouter, Depends, Query, Response
-from rio_tiler.io import COGReader
 from titiler.core.resources.enums import ImageType
 from titiler.core.utils import render_image
 
 from ...crud.sync_db.tile_cache_assets import get_versions
 from ...models.enumerators.tile_caches import TileCacheType
+from ...models.enumerators.titiler import TreeCoverDensityThreshold
 from .. import raster_xyz
-from ...settings.globals import GLOBALS
 from .algorithms.carbon_net_flux import CarbonNetFlux
 from .readers import AlertsReader
 
@@ -22,7 +21,7 @@ dataset = "gfw_forest_carbon_net_flux"
 
 
 class GfwForestCarbonNetFlux(str, Enum):
-    latest = "v20240402"
+    latest = "v20250430"
 
 
 _versions = get_versions(dataset, TileCacheType.cog)
@@ -40,61 +39,27 @@ async def global_forest_carbon_net_flux_raster_tile(
     *,
     version: GfwForestCarbonNetFlux,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
-    tree_cover_density_threshold: int = Query(
-        ge=30,
-        le=100,
-        description="Show net flux in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
-    )
+    tree_cover_density_threshold: Optional[TreeCoverDensityThreshold] = Query(
+        TreeCoverDensityThreshold.tcd_30,
+        description="Show carbon net flux pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
+    ),
 ) -> Response:
     """Forest Carbon Net Flux raster tiles."""
 
     tile_x, tile_y, zoom = xyz
-    bands = ["default", "intensity"]
+    bands = [
+        f"emission_tcd_{tree_cover_density_threshold}",
+        f"intensity_tcd_{tree_cover_density_threshold}",
+    ]
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
-    with AlertsReader(input=folder, default_band="default") as reader:
+    with AlertsReader(input=folder, default_band=bands[0]) as reader:
         # NOTE: the bands in the output `image_data` array will be in the order of
         # the input `bands` list
-        image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
+        image_data = reader.tile(
+            tile_x, tile_y, zoom, bands=bands
+        )
 
-    carbon_net_flux = CarbonNetFlux(
-        tree_cover_density_mask=tree_cover_density_threshold,
-        tree_cover_gain_from_height_mask=0,
-        mangrove_stock_2000_mask=0.0,
-    )
-
-    filter_datasets = GLOBALS.carbon_flux_filters
-
-    filter_dataset = filter_datasets["tree_cover_density"]
-    with COGReader(
-            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
-    ) as reader:
-        if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.tree_cover_density_data = reader.tile(tile_x, tile_y, zoom)
-        else:
-            print("Non-existent tile, tree_cover_density")
-            carbon_net_flux.tree_cover_density_data = None
-
-    filter_dataset = filter_datasets["tree_cover_gain_from_height"]
-    with COGReader(
-        f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
-    ) as reader:
-        if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.tree_cover_gain_from_height_data = reader.tile(tile_x, tile_y, zoom)
-        else:
-            print("Non-existent tile, tree_cover_gain_from_height")
-            carbon_net_flux.tree_cover_gain_from_height_data = None
-
-    filter_dataset = filter_datasets["mangrove_stock_2000"]
-    with COGReader(
-        f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
-    ) as reader:
-        if reader.tile_exists(tile_x, tile_y, zoom):
-            carbon_net_flux.mangrove_stock_2000_data = reader.tile(tile_x, tile_y, zoom)
-        else:
-            print("Non-existent tile, mangrove")
-            carbon_net_flux.mangrove_stock_2000_data = None
-
-    processed_image = carbon_net_flux(image_data)
+    processed_image = CarbonNetFlux()(image_data)
 
     content, media_type = render_image(
         processed_image,


### PR DESCRIPTION
GTC-3232 Update carbon flux/removals titiler endpoints

Update carbon flux and gross removals titiler endpoints to use the fixed TCD rasters (30, 50, 75), rather than trying to arbitrary TCD filtering on the fly.

Update latest to point to v20250430 for emissions and flux, and v20250416 for removals.

Tested locally with the new version of gross_emissions, still building COGs for new version of net_flux.

