### PR TITLE
Use TCL intensity for drivers

### DIFF
--- a/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
+++ b/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
@@ -31,7 +31,8 @@ class TreeCoverLossDrivers(BaseAlgorithm):
     # Value of None for the *_data fields means the tile didn't exist (tile was all
     # no_data).
     tree_cover_density_mask: Optional[int] = None
-    tree_cover_density_data: Optional[ImageData] = None
+    tree_cover_loss_intensity_data: Optional[ImageData] = None
+    zoom: int = 12
 
     # metadata
     input_nbands: int = 2
@@ -41,8 +42,7 @@ class TreeCoverLossDrivers(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
 
         self.driver = img.data[0]
-        self.intensity = img.data[1]
-        self.no_data = img.array.mask[0]
+        self.intensity = self.tree_cover_loss_intensity_data.data[0]
 
         # self.mask should be True for pixels where we have valid data which is not
         # filtered out.
@@ -57,19 +57,9 @@ class TreeCoverLossDrivers(BaseAlgorithm):
         return ImageData(data, assets=img.assets, crs=img.crs, bounds=img.bounds)
 
     def create_mask(self):
-        mask = ~self.no_data
-
-        if self.tree_cover_density_mask:
-            if self.tree_cover_density_data:
-                mask *= (
-                    self.tree_cover_density_data.array[0, :, :]
-                    >= self.tree_cover_density_mask
-                )
-            else:
-                # There was a full no-data tile for tcd, so we should mask
-                # out everything on the base raster.
-                mask = np.zeros_like(mask)
-
+        # it seems to not be creating the mask correctly for non-zero NoData, so just
+        # directly applying the NoData
+        mask = ~((self.driver == 0) & (self.driver == 255))
         return mask
 
     def create_true_color_rgb(self):
@@ -82,22 +72,50 @@ class TreeCoverLossDrivers(BaseAlgorithm):
 
         return np.stack([r, g, b], axis=0)
 
-    def create_true_color_alpha(self):
-        """Set the transparency (alpha) channel based on intensity input. The
-        intensity multiplier is used to control how isolated pixels fade out at low
-        zoom levels, matching the rendering behavior in Flagship.
-
-        Returns:
-            np.ndarray: Array representing the alpha (transparency) channel, where pixel
-            visibility is adjusted by intensity.
-
-        """
-        alpha = np.where(self.mask, self.intensity, 0)
-        return np.minimum(255, alpha)
-
     def _rgb_zeros_array(self):
         r = np.zeros_like(self.driver, dtype=np.uint8)
         g = np.zeros_like(self.driver, dtype=np.uint8)
         b = np.zeros_like(self.driver, dtype=np.uint8)
 
         return r, g, b
+    
+    def create_true_color_alpha(self):
+        # Scale intensity if zoom level < 11, otherwise use original intensity
+        if self.zoom < 11:
+            scale_pow = self.scale_intensity(self.zoom)
+            scaled_intensity = scale_pow(self.intensity).astype("uint8")
+        else:
+            scaled_intensity = self.intensity.astype("uint8")
+
+        alpha = (scaled_intensity if self.zoom < 13 else self.intensity) * self.mask
+        return np.clip(alpha, 0, 255).astype("uint8")
+    
+    @staticmethod
+    def scale_intensity(zoom):
+        """
+        Returns callable that applies power scaling to an array of
+        intensity values based on the given zoom level.
+
+        Adapted from: https://github.com/wri/gfw/blob/develop/providers/datasets-provider/config.js#L28
+        """
+        
+        # Exponent for the power scaling function (only when below raw data resolution of zoom 12)
+        exp = 0.3 + ((zoom - 3) / 20) if zoom < 11 else 1
+        
+        # Min/max of input intensity values
+        domain = (0, 255)
+
+        # Min/max of scaled output intensity values
+        scale_range = (0, 255)
+
+        # Scaling factor that ensures the scaled intensity value is below the max value
+        scaling_factor = scale_range[1] / domain[1] ** exp
+
+        # Scaling offset based on min of input intensity value
+        b = scale_range[0]
+
+        # Apply the power scaling function to an array of intensity values
+        def scale_pow(x: np.ndarray) -> np.ndarray:
+            return scaling_factor * x**exp + b
+
+        return scale_pow

--- a/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
+++ b/app/routes/titiler/algorithms/tree_cover_loss_drivers.py
@@ -42,7 +42,12 @@ class TreeCoverLossDrivers(BaseAlgorithm):
     def __call__(self, img: ImageData) -> ImageData:
 
         self.driver = img.data[0]
-        self.intensity = self.tree_cover_loss_intensity_data.data[0]
+
+        if self.tree_cover_loss_intensity_data is not None:
+            self.intensity = self.tree_cover_loss_intensity_data.data[0]
+        else:
+            # if intensity is defined for area, just set everything to 255 to ignore opacity
+            self.intensity = np.ones_like(self.driver) * 255
 
         # self.mask should be True for pixels where we have valid data which is not
         # filtered out.
@@ -87,7 +92,7 @@ class TreeCoverLossDrivers(BaseAlgorithm):
         else:
             scaled_intensity = self.intensity.astype("uint8")
 
-        alpha = (scaled_intensity if self.zoom < 13 else self.intensity) * self.mask
+        alpha = scaled_intensity * self.mask
         return np.clip(alpha, 0, 255).astype("uint8")
     
     @staticmethod
@@ -99,7 +104,7 @@ class TreeCoverLossDrivers(BaseAlgorithm):
         Adapted from: https://github.com/wri/gfw/blob/develop/providers/datasets-provider/config.js#L28
         """
         
-        # Exponent for the power scaling function (only when below raw data resolution of zoom 12)
+        # Exponent for the power scaling function (only when below raw data resolution of zoom 11)
         exp = 0.3 + ((zoom - 3) / 20) if zoom < 11 else 1
         
         # Min/max of input intensity values
@@ -109,7 +114,7 @@ class TreeCoverLossDrivers(BaseAlgorithm):
         scale_range = (0, 255)
 
         # Scaling factor that ensures the scaled intensity value is below the max value
-        scaling_factor = scale_range[1] / domain[1] ** exp
+        scaling_factor = scale_range[1] / (domain[1] ** exp)
 
         # Scaling offset based on min of input intensity value
         b = scale_range[0]

--- a/app/routes/titiler/readers.py
+++ b/app/routes/titiler/readers.py
@@ -40,3 +40,4 @@ class AlertsReader(MultiBandReader):
     def _get_band_url(self, band: str) -> str:
         """Validate band's name and return band's url."""
         return f"{self.input}/{band}.tif"
+

--- a/app/routes/titiler/wri_tree_cover_loss_drivers.py
+++ b/app/routes/titiler/wri_tree_cover_loss_drivers.py
@@ -49,7 +49,7 @@ async def tree_cover_loss_drivers_raster_tile(
     """Tree cover loss drivers raster tiles."""
 
     tile_x, tile_y, zoom = xyz
-    bands = ["default", "intensity"]
+    bands = ["default"]
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
     with AlertsReader(input=folder, default_band="default") as reader:
         # NOTE: the bands in the output `image_data` array will be in the order of
@@ -57,20 +57,20 @@ async def tree_cover_loss_drivers_raster_tile(
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
 
     tree_cover_loss_drivers = TreeCoverLossDrivers(
-        tree_cover_density_mask=tree_cover_density_threshold,
+        tree_cover_density_mask=tree_cover_density_threshold, zoom=zoom
     )
 
     filter_datasets = GLOBALS.tree_cover_loss_drivers_filters
 
-    filter_dataset = filter_datasets["tree_cover_density"]
+    filter_dataset = filter_datasets["tree_cover_loss"]
     with COGReader(
-            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
+            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/intensity__tcd{tree_cover_density_threshold}_2000.tif"
     ) as reader:
         if reader.tile_exists(tile_x, tile_y, zoom):
-            tree_cover_loss_drivers.tree_cover_density_data = reader.tile(tile_x, tile_y, zoom)
+            tree_cover_loss_drivers.tree_cover_loss_intensity_data = reader.tile(tile_x, tile_y, zoom)
         else:
             print("Non-existent tile, tree_cover_density")
-            tree_cover_loss_drivers.tree_cover_density_data = None
+            tree_cover_loss_drivers.tree_cover_intensity_data = None
 
     processed_image = tree_cover_loss_drivers(image_data)
 

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -27,7 +27,7 @@ carbon_flux_filters = {
 }
 
 tree_cover_loss_drivers_filters = {
-    "tree_cover_density": {"dataset": "umd_tree_cover_density_2000", "version": "v1.8"},
+    "tree_cover_loss": {"dataset": "umd_tree_cover_loss", "version": "v1.12"},
 }
 
 


### PR DESCRIPTION
- Use thresholded TCL intensity for filtering drivers by TCD
- Use TCL method intensity scaling so more shows up at higher zoomer levels