### PR TITLE
Update to TCL 2024 for the forest filter for Dist alerts

### DIFF
--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -12,7 +12,7 @@ from ..models.pydantic.database import DatabaseURL
 # NOTE: For non-local deployment, need to update dataset/version here until the terraform
 # JSON decode issue preventing setting this env variable is resolved.
 dist_alerts_forest_filters = {
-    "tree_cover_loss": {"dataset": "umd_tree_cover_loss", "version": "v1.11"},
+    "tree_cover_loss": {"dataset": "umd_tree_cover_loss", "version": "latest"},
     "tree_cover_height": {"dataset": "umd_tree_cover_height_2020", "version": "v2022"},
     "tree_cover_density": {"dataset": "umd_tree_cover_density_2010", "version": "v1.6"},
 }


### PR DESCRIPTION
Update to TCL 2024 for the titiler forest filter for Dist alerts

Changing to 'latest' for the version, so we don't have to update this every year.
