### PR TITLE
GPV-4888 Add 0%-canopy option for TCL titiler endpoint (unfiltered TCL) 

### DIFF
--- a/app/models/enumerators/titiler.py
+++ b/app/models/enumerators/titiler.py
@@ -25,6 +25,7 @@ class TreeCoverDensityThreshold(str, Enum):
 
 
 class TCLTreeCoverDensityThreshold(str, Enum):
+    tcd_0  = 0
     tcd_10 = 10
     tcd_15 = 15
     tcd_20 = 20


### PR DESCRIPTION
GPV-4888 Add 0%-canopy option (unfiltered TCL).

Pro needs 0%-canopy option, because EUDR needs to see tree-cover loss since 2020 with 10% canopy (as of 2020), but that doesn't always show for TCL 10% filter, because that canopy filter is based on canopy as of 2000.
