### PR TITLE
GTC-3357 Add forest filter to gfw_integrated_dist_alerts titiler endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 tiangolo/uvicorn-gunicorn-fastapi:python3.10-slim
 ARG ENV
 
 RUN apt-get -y update && apt-get -y --no-install-recommends install \
-        make gcc libc-dev libgeos-dev musl-dev libpq-dev libffi-dev jq
+        make gcc libc-dev libgeos-dev musl-dev libpq-dev libffi-dev jq openssh-client
 
 RUN pip install --upgrade pip && pip install pipenv==v2022.11.30
 RUN pip install newrelic

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ to access the database. If so, you can interrupt `scripts/develop` after it has 
 the docker and gotten hung accessing the database. You can then start the docker by
 hand via:
 
-```docker run -it -p 127.0.0.1:8088:80 --entrypoint /bin/bash gfw-tile-cache_app:latest```
+```docker run -it -p 127.0.0.1:8088:80 --entrypoint /bin/bash gfw-tile-cache-app:latest```
 
 In that case, you will need to copy your `.ssh/id_rsa` and `.aws/credentials` files
 into the docker and set all the needed environmental variables in the shell. You then

--- a/app/routes/titiler/algorithms/alerts.py
+++ b/app/routes/titiler/algorithms/alerts.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict, namedtuple
 from typing import Optional
 
+from pydantic import ConfigDict
 import numpy as np
 from fastapi.logger import logger
 from rio_tiler.models import ImageData
@@ -18,6 +19,7 @@ class Alerts(BaseAlgorithm):
     title: str = "Deforestation Alerts"
     description: str = "Decode and visualize alerts"
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     conf_colors: OrderedDict = OrderedDict(
         {
             IntegratedAlertConfidence.low: AlertConfig(
@@ -38,6 +40,17 @@ class Alerts(BaseAlgorithm):
     end_date: Optional[str] = None
     alert_confidence: Optional[str] = None
     render_type: RenderType = RenderType.true_color
+
+    tree_cover_density_mask: Optional[int] = None
+    tree_cover_density_data: Optional[ImageData] = None
+
+    tree_cover_height_mask: Optional[int] = None
+    tree_cover_height_data: Optional[ImageData] = None
+
+    # the highest loss year that is used to exclude alerts for
+    # the purpose of showing only alerts in forests
+    tree_cover_loss_mask: Optional[int] = None
+    tree_cover_loss_data: Optional[ImageData] = None
 
     # metadata
     input_nbands: int = 2
@@ -106,6 +119,28 @@ class Alerts(BaseAlgorithm):
                 np.datetime64(self.end_date) - np.datetime64(self.record_start_date)
             )
             mask *= end_mask
+
+        if self.tree_cover_density_mask:
+            mask *= (
+                self.tree_cover_density_data.array[0, :, :]
+                >= self.tree_cover_density_mask
+            )
+
+        if self.tree_cover_height_mask:
+            mask *= (
+                self.tree_cover_height_data.array[0, :, :]
+                >= self.tree_cover_height_mask
+            )
+
+        if self.tree_cover_loss_mask:
+            # Tree cover loss data before 2020 can't be used to filter out pixels as not forest.
+            # Instead, we use tree cover height taken that year as source of truth.
+            # For example, if a pixel had tree cover loss in 2018, but has tree cover
+            # height (2020) that meets the forest threshold, the pixel meets
+            # the forest criteria for alerts and is not masked out.
+            mask *= (
+                self.tree_cover_loss_data.array[0, :, :] > self.tree_cover_loss_mask
+            ) | (self.tree_cover_loss_data.array[0, :, :] <= 2020)
 
         return mask
 

--- a/app/routes/titiler/algorithms/dist_alerts.py
+++ b/app/routes/titiler/algorithms/dist_alerts.py
@@ -37,30 +37,3 @@ class DISTAlerts(Alerts):
     # the purpose of showing only alerts in forests
     tree_cover_loss_mask: Optional[int] = None
     tree_cover_loss_data: Optional[ImageData] = None
-
-    def create_mask(self):
-        mask = super().create_mask()
-
-        if self.tree_cover_density_mask:
-            mask *= (
-                self.tree_cover_density_data.array[0, :, :]
-                >= self.tree_cover_density_mask
-            )
-
-        if self.tree_cover_height_mask:
-            mask *= (
-                self.tree_cover_height_data.array[0, :, :]
-                >= self.tree_cover_height_mask
-            )
-
-        if self.tree_cover_loss_mask:
-            # Tree cover loss data before 2020 can't be used to filter out pixels as not forest.
-            # Instead, we use tree cover height taken that year as source of truth.
-            # For example, if a pixel had tree cover loss in 2018, but has tree cover
-            # height (2020) that meets the forest threshold, the pixel meets
-            # the forest criteria for alerts and is not masked out.
-            mask *= (
-                self.tree_cover_loss_data.array[0, :, :] > self.tree_cover_loss_mask
-            ) | (self.tree_cover_loss_data.array[0, :, :] <= 2020)
-
-        return mask

--- a/app/routes/titiler/gfw_integrated_dist_alerts.py
+++ b/app/routes/titiler/gfw_integrated_dist_alerts.py
@@ -2,10 +2,12 @@ import os
 from typing import Optional, Tuple
 
 from fastapi import APIRouter, Depends, Query, Response, Path
+from rio_tiler.io import COGReader
 from titiler.core.resources.enums import ImageType
 from titiler.core.utils import render_image
 
 from ...models.enumerators.titiler import IntegratedAlertConfidence, RenderType
+from ...settings.globals import GLOBALS
 from .. import DATE_REGEX, raster_xyz
 from .algorithms.integrated_alerts import IntegratedAlerts
 from .readers import AlertsReader
@@ -17,7 +19,7 @@ router = APIRouter()
 dataset = "gfw_integrated_dist_alerts"
 
 # We don't set a fixed set of versions that can be used, since we want to be able
-# to serve any new integrated_dist_alerts version created since this server started.
+# to serve any new gfw_integrated_dist_alerts version created since this server started.
 
 
 @router.get(
@@ -50,6 +52,21 @@ async def gfw_integrated_alerts_raster_tile(
         IntegratedAlertConfidence.low,
         description="Show alerts with at least this confidence level",
     ),
+    tree_cover_density_threshold: Optional[int] = Query(
+        None,
+        ge=0,
+        le=100,
+        description="Show alerts in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2010` is used for this masking.",
+    ),
+    tree_cover_height_threshold: Optional[int] = Query(
+        None,
+        description="Show alerts in pixels with tree cover height (in meters) greater than or equal to this threshold. `umd_tree_cover_height_2020` dataset in the API is used for this masking.",
+    ),
+    tree_cover_loss_threshold: Optional[int] = Query(
+        None,
+        ge=2021,
+        description="""This filter is to be used in conjunction with `tree_cover_density_threshold` and `tree_cover_height_threshold` filters to detect only alerts in forests, by masking out pixels that have had tree cover loss prior to the alert.""",
+    ),
 ) -> Response:
     """GFW Integrated Disturbance Alerts raster tiles."""
 
@@ -59,12 +76,39 @@ async def gfw_integrated_alerts_raster_tile(
         tile_x, tile_y, zoom = xyz
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
 
-    processed_image = IntegratedAlerts(
+    int_dist_alert = IntegratedAlerts(
         start_date=start_date,
         end_date=end_date,
         render_type=render_type,
         alert_confidence=alert_confidence,
-    )(image_data)
+        tree_cover_density_mask=tree_cover_density_threshold,
+        tree_cover_height_mask=tree_cover_height_threshold,
+        tree_cover_loss_mask=tree_cover_loss_threshold,
+    )
+
+    filter_datasets = GLOBALS.dist_alerts_forest_filters
+    if tree_cover_density_threshold:
+        filter_dataset = filter_datasets["tree_cover_density"]
+        with COGReader(
+            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
+        ) as reader:
+            int_dist_alert.tree_cover_density_data = reader.tile(tile_x, tile_y, zoom)
+
+    if tree_cover_height_threshold:
+        filter_dataset = filter_datasets["tree_cover_height"]
+        with COGReader(
+            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
+        ) as reader:
+            int_dist_alert.tree_cover_height_data = reader.tile(tile_x, tile_y, zoom)
+
+    if tree_cover_loss_threshold:
+        filter_dataset = filter_datasets["tree_cover_loss"]
+        with COGReader(
+            f"s3://{DATA_LAKE_BUCKET}/{filter_dataset['dataset']}/{filter_dataset['version']}/raster/epsg-4326/cog/default.tif"
+        ) as reader:
+            int_dist_alert.tree_cover_loss_data = reader.tile(tile_x, tile_y, zoom)
+
+    processed_image = int_dist_alert(image_data)
 
     content, media_type = render_image(
         processed_image,


### PR DESCRIPTION
GTC-3357 Add forest filter to gfw_integrated_dist_alerts titiler endpoint

This is request by Pro folks for integrated dist alerts, same as  forest filter for dist alerts.

I moved most of the forest filter code down to the Alerts class, so it can be shared between DistAlerts and gfw_integrated_dist_alerts.py (which uses IntegratedAlerts). It could also be used by other Alerts subclasses.

Dist alerts no longer needs a create_mask method, since it is fully handled by the Alerts create_mask method.

Dockerfile change is just to add ssh-client to test docker, which makes it easier for me to test dev changes on Linux with production DB.
