### PR TITLE
Make sure to apply tree cover filter for encoded int-dist alerts

### DIFF
--- a/app/routes/titiler/algorithms/alerts.py
+++ b/app/routes/titiler/algorithms/alerts.py
@@ -91,12 +91,14 @@ class Alerts(BaseAlgorithm):
         return ImageData(data, assets=img.assets, crs=img.crs, bounds=img.bounds)
 
     def create_mask(self):
-        """Generate a mask for pixel visibility based on date and confidence
-        filters, and no data values.
+        """Generate a mask for pixel visibility based no data valules, date and
+        confidence filters, and (only when render type is true_color) any tree-cover
+        filters that are specified.
 
         Returns:
-            np.ndarray: A mask array pixels with no alert or alerts not meeting filter
-            condition are masked.
+            np.ndarray: A mask array (where False means mask the pixel). Pixels
+            with no alerts or alerts not meeting filter condition are masked.
+
         """
 
         mask = ~self.no_data

--- a/app/routes/titiler/algorithms/alerts.py
+++ b/app/routes/titiler/algorithms/alerts.py
@@ -101,25 +101,30 @@ class Alerts(BaseAlgorithm):
 
         mask = ~self.no_data
 
-        if self.alert_confidence:
-            confidence_mask = (
-                self.data_alert_confidence
-                >= self.conf_colors[self.alert_confidence].confidence
-            )
-            mask *= confidence_mask
+        if self.render_type == RenderType.true_color:
+            # Only apply alert_confidence, start_date, and end_date filters to the
+            # mask if we are doing render_type of "true_color". For render_type of
+            # "encoded", we want all dates and confidences.
+            if self.alert_confidence:
+                confidence_mask = (
+                    self.data_alert_confidence
+                    >= self.conf_colors[self.alert_confidence].confidence
+                )
+                mask *= confidence_mask
 
-        if self.start_date:
-            start_mask = self.alert_date >= (
-                np.datetime64(self.start_date) - np.datetime64(self.record_start_date)
-            )
-            mask *= start_mask
+            if self.start_date:
+                start_mask = self.alert_date >= (
+                    np.datetime64(self.start_date) - np.datetime64(self.record_start_date)
+                )
+                mask *= start_mask
 
-        if self.end_date:
-            end_mask = self.alert_date <= (
-                np.datetime64(self.end_date) - np.datetime64(self.record_start_date)
-            )
-            mask *= end_mask
+            if self.end_date:
+                end_mask = self.alert_date <= (
+                    np.datetime64(self.end_date) - np.datetime64(self.record_start_date)
+                )
+                mask *= end_mask
 
+        # We apply the tree cover filters for both "true_color" and "encoded".
         if self.tree_cover_density_mask:
             mask *= (
                 self.tree_cover_density_data.array[0, :, :]

--- a/app/routes/titiler/algorithms/integrated_alerts.py
+++ b/app/routes/titiler/algorithms/integrated_alerts.py
@@ -49,4 +49,11 @@ class IntegratedAlerts(Alerts):
         alpha[self.data_alert_confidence == self.conf_colors["high"].confidence] = 8
         alpha[self.data_alert_confidence == self.conf_colors["highest"].confidence] = 24
 
+        # When we are doing encoded gfw_integrated_dist_alerts, we still need to
+        # apply a tree cover filter, if provided. When render_type is encoded,
+        # Alerts.create_mask() will build the mask using only the tree cover
+        # parameters, and then we use that mask here. Integrated alerts doesn't have
+        # tree cover parameters, so self.mask will just ~self.no_data.
+        alpha = np.where(self.mask, alpha, 0)
+
         return alpha

--- a/app/routes/titiler/gfw_integrated_dist_alerts.py
+++ b/app/routes/titiler/gfw_integrated_dist_alerts.py
@@ -70,10 +70,10 @@ async def gfw_integrated_alerts_raster_tile(
 ) -> Response:
     """GFW Integrated Disturbance Alerts raster tiles."""
 
+    tile_x, tile_y, zoom = xyz
     bands = ["default", "intensity"]
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
     with AlertsReader(input=folder, default_band=bands[0]) as reader:
-        tile_x, tile_y, zoom = xyz
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)
 
     int_dist_alert = IntegratedAlerts(


### PR DESCRIPTION
The tree-cover filter wasn't being applied, because int-dist alerts uses the create_encoded_alpha() method of IntegratedAlerts, and that doesn't refer to the mask at all.  So, added a line in IntegratedAlerts.create_encoded_alpha() to use the computed mask (which will just be ~self.no_data for actual integrated_alerts).  In alerts.py, I make sure that the mask for encoded type does not include start_date, end_data, and confidence, since those should never be used to mask encoded data.