### PR TITLE
GTC-3461 Changes need to display int-dist alerts with split COGs.

### DIFF
--- a/app/routes/titiler/gfw_integrated_dist_alerts.py
+++ b/app/routes/titiler/gfw_integrated_dist_alerts.py
@@ -71,7 +71,15 @@ async def gfw_integrated_alerts_raster_tile(
     """GFW Integrated Disturbance Alerts raster tiles."""
 
     tile_x, tile_y, zoom = xyz
-    bands = ["default", "intensity"]
+
+    # These VRTs for the split int-dist COGs are created in the datapump by commands
+    # like:
+    # 
+    # gdalbuildvrt intdist.vrt /vsis3/gfw-data-lake/gfw_integrated_dist_alerts/v20260228/raster/epsg-4326/cog/nonoverlap.tif /vsis3/gfw-data-lake/gfw_integrated_dist_alerts/v20260228/raster/epsg-4326/cog/overlap.tif
+    #
+    # gdalbuildvrt intdistintensity.vrt /vsis3/gfw-data-lake/gfw_integrated_dist_alerts/v20260228/raster/epsg-4326/cog/nonoverlapintensity.tif /vsis3/gfw-data-lake/gfw_integrated_dist_alerts/v20260228/raster/epsg-4326/cog/overlapintensity.tif
+    bands = ["intdist.vrt", "intdistintensity.vrt"]
+
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
     with AlertsReader(input=folder, default_band=bands[0]) as reader:
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands)

--- a/app/routes/titiler/readers.py
+++ b/app/routes/titiler/readers.py
@@ -39,5 +39,7 @@ class AlertsReader(MultiBandReader):
 
     def _get_band_url(self, band: str) -> str:
         """Validate band's name and return band's url."""
-        return f"{self.input}/{band}.tif"
-
+        if band.endswith(".vrt"):
+            return f"{self.input}/{band}"
+        else:
+            return f"{self.input}/{band}.tif"


### PR DESCRIPTION
GTC-3461 Changes need to display int-dist alerts with split COGs.

All the big changes to create the split COGs nightly/weekly have already been done in the datapump.