### PR TITLE
allow filtering to one year; remove hardcoding

### DIFF
--- a/app/routes/titiler/algorithms/tree_cover_loss_base.py
+++ b/app/routes/titiler/algorithms/tree_cover_loss_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, ClassVar, Optional
 
 import numpy as np
 from pydantic import ConfigDict
@@ -16,8 +16,11 @@ class TreeCoverLossBase(BaseAlgorithm, ABC):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    start_date: Optional[int] = 2001
-    end_year: Optional[int] = 2024
+    DEFAULT_START_YEAR: ClassVar[int] = 2001
+    DEFAULT_END_YEAR: ClassVar[int] = 2025
+
+    start_year: Optional[int] = DEFAULT_START_YEAR
+    end_year: Optional[int] = DEFAULT_END_YEAR
     render_type: RenderType = RenderType.true_color
     zoom: int = 12
     tree_cover_density_threshold: Optional[int] = None
@@ -55,11 +58,11 @@ class TreeCoverLossBase(BaseAlgorithm, ABC):
         mask = ~self.no_data
 
         # TCL goes from 2001 to 2024 by default, only filter if start_year or end_year is specified
-        if self.start_year != 2001:
+        if self.start_year != self.DEFAULT_START_YEAR:
             start_mask = self.tree_cover_loss_data >= (self.start_year - 2000)
             mask &= start_mask
 
-        if self.end_year != 2024:
+        if self.end_year != self.DEFAULT_END_YEAR:
             end_mask = self.tree_cover_loss_data <= (self.end_year - 2000)
             mask &= end_mask
 

--- a/app/routes/titiler/umd_tree_cover_loss.py
+++ b/app/routes/titiler/umd_tree_cover_loss.py
@@ -38,10 +38,16 @@ async def umd_tree_cover_loss_raster_tile(
     version: UmdTreeCoverLossVersions,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
     start_year: Optional[int] = Query(
-        2001, ge=2001, le=2024, description="Only show loss for given year and after"
+        TreeCoverLoss.DEFAULT_START_YEAR,
+        ge=TreeCoverLoss.DEFAULT_START_YEAR,
+        le=TreeCoverLoss.DEFAULT_END_YEAR,
+        description="Only show loss for given year and after",
     ),
     end_year: Optional[int] = Query(
-        2025, ge=2002, le=2025, description="Only show loss until given year."
+        TreeCoverLoss.DEFAULT_END_YEAR,
+        ge=TreeCoverLoss.DEFAULT_START_YEAR,
+        le=TreeCoverLoss.DEFAULT_END_YEAR,
+        description="Only show loss until given year.",
     ),
     render_type: RenderType = Query(
         RenderType.encoded, description="Render true color or encoded tiles"

--- a/app/routes/titiler/umd_tree_cover_loss_from_fires.py
+++ b/app/routes/titiler/umd_tree_cover_loss_from_fires.py
@@ -38,10 +38,10 @@ async def umd_tree_cover_loss_raster_tile(
     version: UmdTreeCoverLossFromFiresVersions,
     xyz: Tuple[int, int, int] = Depends(raster_xyz),
     start_year: Optional[int] = Query(
-        2001, ge=2001, le=2023, description="Only show loss for given year and after"
+        TreeCoverLossFromFires.DEFAULT_START_YEAR, ge=TreeCoverLossFromFires.DEFAULT_START_YEAR, le=TreeCoverLossFromFires.DEFAULT_END_YEAR, description="Only show loss for given year and after"
     ),
     end_year: Optional[int] = Query(
-        2023, ge=2002, le=2024, description="Only show loss until given year."
+        TreeCoverLossFromFires.DEFAULT_END_YEAR, ge=TreeCoverLossFromFires.DEFAULT_START_YEAR, le=TreeCoverLossFromFires.DEFAULT_END_YEAR, description="Only show loss until given year."
     ),
     render_type: RenderType = Query(
         RenderType.encoded, description="Render true color or encoded tiles"


### PR DESCRIPTION
This fixes a bug reported in GNW that's preventing filtering tree cover loss to just one year of loss. Also got rid of hardcoded tcl start and end year.
