### PR TITLE
GPV-5483 Support tcd filter value of 0 for Pro

### DIFF
--- a/app/models/enumerators/titiler.py
+++ b/app/models/enumerators/titiler.py
@@ -31,6 +31,7 @@ class TreeCoverDensityThreshold(StrEnum):
 
 
 class TCLTreeCoverDensityThreshold(StrEnum):
+    tcd_0 = "0"
     tcd_10 = "10"
     tcd_15 = "15"
     tcd_20 = "20"

--- a/app/routes/titiler/tree_cover_loss_core.py
+++ b/app/routes/titiler/tree_cover_loss_core.py
@@ -25,18 +25,14 @@ async def tree_cover_loss_core(
     end_year: Optional[int],
     render_type: RenderType,
     tcd: Optional[TCLTreeCoverDensityThreshold] = Query(
-        None,
+        "30",
         description="Show tree cover loss in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking."
     ),
-    bands: list[str] = ["default", "intensity"],
 ) -> Response:
     tile_x, tile_y, zoom = xyz
     folder: str = f"s3://{DATA_LAKE_BUCKET}/{dataset}/{version}/raster/epsg-4326/cog"
 
-    if tcd is not None:
-        bands = [f"year__tcd{tcd}_2000", f"intensity__tcd{tcd}_2000"]
-    else: # tcd is None
-        bands = ["default", "intensity"]
+    bands = [f"year__tcd{tcd}_2000", f"intensity__tcd{tcd}_2000"]
 
     with AlertsReader(input=folder) as reader:
         image_data = reader.tile(tile_x, tile_y, zoom, bands=bands, tilesize=512)

--- a/app/routes/titiler/umd_tree_cover_loss.py
+++ b/app/routes/titiler/umd_tree_cover_loss.py
@@ -53,11 +53,11 @@ async def umd_tree_cover_loss_raster_tile(
         RenderType.encoded, description="Render true color or encoded tiles"
     ),
     tree_cover_density_threshold: Optional[TCLTreeCoverDensityThreshold] = Query(
-        None,
+        "30",
         description="Show tree cover loss in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
     ),
     tcd: Optional[TCLTreeCoverDensityThreshold] = Query(
-        None,
+        "30",
         description="Same as `tree_cover_density_threshold`",
         include_in_schema=False,
     ),

--- a/app/routes/titiler/umd_tree_cover_loss_from_fires.py
+++ b/app/routes/titiler/umd_tree_cover_loss_from_fires.py
@@ -53,11 +53,11 @@ async def umd_tree_cover_loss_raster_tile(
         RenderType.encoded, description="Render true color or encoded tiles"
     ),
     tree_cover_density_threshold: Optional[TCLTreeCoverDensityThreshold] = Query(
-        None,
+        "30",
         description="Show tree cover loss in pixels with tree cover density (in percent) greater than or equal to this threshold. `umd_tree_cover_density_2000` is used for this masking.",
     ),
     tcd: Optional[TCLTreeCoverDensityThreshold] = Query(
-        None,
+        "30",
         description="Same as `tree_cover_density_threshold`",
         include_in_schema=False,
     ),


### PR DESCRIPTION
Pro wants to be able to show tree cover loss with tree cover density threshold of zero. Added that value to the enum and and generated the necessary COGs with the appropriate name.

Also, made it clearer that the default display (no TCD value) is to use 30% canopy density. Don't use the default/intensity cogs, because those were not generated by Data API in the standard way.

Got rid of unused 'bands' argument to tree_cover_loss_core().

